### PR TITLE
Fix bug on creating new link

### DIFF
--- a/components/Admin/Context/links.js
+++ b/components/Admin/Context/links.js
@@ -13,7 +13,7 @@ export const reducer = async (links, action) => {
     case 'INIT':
       return newLinks;
     case 'CREATE':
-      link.index = links.length;
+      link.index = links[links.length - 1].index + 1;
       response = await API.post('/links', link);
       return [...links, response.data.data];
     case 'DELETE':

--- a/components/Admin/LinksTable/Actions.js
+++ b/components/Admin/LinksTable/Actions.js
@@ -9,7 +9,7 @@ function Actions({ record }) {
 
   const confirmDelete = () => {
     setLoading(true);
-    dispatch({ type: 'DELETE', id: record._id });
+    dispatch({ type: 'DELETE', id: record._id, index: record.index });
     setVisible(false);
     setLoading(false);
   };


### PR DESCRIPTION
It is not correct to assume that the largest index is equal to the size of the array minus one, this
is because when a link is deleted, the indexes of the links are not reordered, since updating the
indexes is an expensive task, it only happens when reordering links.