### PR TITLE
Remove APP URL for easier deployment in different environments

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,5 +3,4 @@ AUTH0_BASE_URL=http://localhost:3000
 AUTH0_ISSUER_BASE_URL=<base_url>
 AUTH0_CLIENT_ID=<client id>
 AUTH0_CLIENT_SECRET=<client secret>
-NEXT_PUBLIC_APP_URL=http://localhost:3000
 MONGODB_URI=<mongodb uri>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,13 +1,6 @@
 import axios from 'redaxios';
 
-let APP_URL = process.env.NEXT_PUBLIC_APP_URL;
-
-if (!/^https?:\/\//i.test(APP_URL)) {
-  APP_URL = 'http://' + APP_URL;
-}
-
 const API = axios.create({
-  baseURL: `${APP_URL}`,
   responseType: 'json',
   headers: {
     'Content-Type': 'application/json'


### PR DESCRIPTION
This makes it easier to have multiple environments since we don't need to keep track of which domain we are testing (it's the one we are at the moment).